### PR TITLE
yerbamate 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1.6 / 2017-07-07
+==================
+
+  * Execution path is now resolved, paths like (`~`) are now supported
+
 1.1.5 / 2017-06-19
 ==================
 

--- a/app/runner.js
+++ b/app/runner.js
@@ -1,8 +1,10 @@
 var process = require('child_process');
+var path = require('path');
 
 function filterOutput(out) {
     return out.split('\n').filter(Boolean);
 }
+
 
 module.exports = function(command, dir, options, done) {
     if (!done && typeof options === 'function') {
@@ -20,7 +22,10 @@ module.exports = function(command, dir, options, done) {
         shell: true
     };
     var args = [];
-    if (dir) execOptions.cwd = dir;
+    if (dir) {
+        dir = path.resolve(dir);
+        execOptions.cwd = dir;
+    }
     if (options.args) {
         if (options.args.constructor === Array) {
             args = options.args;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yerbamate",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yerbamate",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Test oriented task runner library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
  * Execution path is now resolved, paths like (`~`) are now supported